### PR TITLE
DocWorks for wix-media-manager-backend - 8 changes detected, but 2 is…

### DIFF
--- a/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
+++ b/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
@@ -21,8 +21,7 @@
   "properties": [],
   "operations":
     [ { "name": "downloadFiles",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "fileUrls",
@@ -193,8 +192,7 @@
         "extra":
           {  } },
       { "name": "getDownloadUrl",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",
@@ -305,8 +303,7 @@
         "extra":
           {  } },
       { "name": "getFileInfo",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",
@@ -649,7 +646,7 @@
               [ "The `getVideoPlaybackUrl()` function returns a Promise that resolves to the",
                 " specified video file's playback URL.",
                 "",
-                " Pass each file's URL in the `fileUrl` parameter,",
+                " Pass the file's URL in the `fileUrl` parameter,",
                 " as returned in the `fileUrl` property from the [`getFileInfo()`](#getFileInfo),",
                 " [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions." ],
             "links": [],
@@ -1167,8 +1164,7 @@
         "extra":
           {  } },
       { "name": "moveFilesToTrash",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "fileUrls",

--- a/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
+++ b/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
@@ -46,8 +46,9 @@
               [ "The `downloadFiles()` function returns a Promise that resolves to a download URL ",
                 " for the specified file(s).",
                 "",
-                " Pass each file's URL in the `fileUrl` parameter, as returned ",
-                " in the `fileUrl` property of the `getFileInfo`, `importFile()`, `upload()`, and `listFiles()` functions.",
+                " Pass each file's URL in the `fileUrl` parameter,",
+                " as returned in the `fileUrl` property from the [`getFileInfo()`](#getFileInfo),",
+                " [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions. ",
                 "",
                 " A compressed file is created and can be downloaded using the download URL. The compressed ",
                 " file can contain up to 1000 files.",
@@ -192,7 +193,8 @@
         "extra":
           {  } },
       { "name": "getDownloadUrl",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",
@@ -225,8 +227,9 @@
               [ "The `getDownloadUrl()` function returns a Promise that resolves to ",
                 " a download URL for a specified file in the Media Manager. ",
                 "",
-                " Pass the file's URL in the `fileUrl` parameter, as returned ",
-                " in the `fileUrl` property of the `getFileInfo()`, `importFile()`, `upload()`, and `listFiles()` functions.",
+                " Pass the file's URL in the `fileUrl` parameter,",
+                " as returned in the `fileUrl` property from the [`getFileInfo()`](#getFileInfo),",
+                " [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions. ",
                 " When the download URL is clicked, the specified file downloads to your device. ",
                 "",
                 " You can use the `getDownloadUrl()` function to allow external clients to download a file from the Media Manager to their device.",
@@ -324,8 +327,9 @@
               [ "The `getFileInfo()` function returns a Promise that resolves to information about",
                 " the specified file. ",
                 " ",
-                " Pass the file's URL in the `fileUrl` parameter, as returned ",
-                " in the `fileUrl` property of the `importFile()`, `upload()`, and `listFiles()` functions." ],
+                " Pass each file's URL in the `fileUrl` parameter,",
+                " as returned in the `fileUrl` property from the [`getFileInfo()`](#getFileInfo),",
+                " [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions." ],
             "links": [],
             "examples":
               [ { "title": "Get a file's information",
@@ -645,8 +649,9 @@
               [ "The `getVideoPlaybackUrl()` function returns a Promise that resolves to the",
                 " specified video file's playback URL.",
                 "",
-                " Pass the file's URL in the `fileUrl` parameter, as returned ",
-                " in the `fileUrl` property of the `getFileInfo`, `importFile()`, `upload()`, and `listFiles()` functions." ],
+                " Pass each file's URL in the `fileUrl` parameter,",
+                " as returned in the `fileUrl` property from the [`getFileInfo()`](#getFileInfo),",
+                " [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions." ],
             "links": [],
             "examples":
               [ { "title": "Get a URL to be used for video playback",
@@ -667,8 +672,7 @@
         "extra":
           {  } },
       { "name": "importFile",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "path",
@@ -1188,8 +1192,9 @@
               [ "The `moveFilesToTrash()` function returns a Promise that resolves when the file(s) are ",
                 " moved to the Media Manager's trash.",
                 "",
-                " Pass each file's URL in the `fileUrl` parameter, as returned ",
-                " in the `fileUrl` property of the `getFileInfo`, `importFile()`, `upload()`, and `listFiles()` functions.",
+                " Pass each file's URL in the `fileUrl` parameter,",
+                " as returned in the `fileUrl` property from the [`getFileInfo()`](#getFileInfo),",
+                " [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions. ",
                 "",
                 " Moving many files to trash at once is an asynchronous action. It may take some time",
                 " for the results to be seen in the Media Manager.",
@@ -2062,8 +2067,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "MetadataOptions",
         "locations":
           [ { "lineno": 70,
@@ -2236,8 +2240,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "PaginationOptions",
         "locations":
           [ { "lineno": 47,
@@ -2489,8 +2492,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "UploadUrl",
         "locations":
           [ { "lineno": 191,

--- a/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
+++ b/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
@@ -303,7 +303,8 @@
         "extra":
           {  } },
       { "name": "getFileInfo",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",
@@ -324,9 +325,8 @@
               [ "The `getFileInfo()` function returns a Promise that resolves to information about",
                 " the specified file. ",
                 " ",
-                " Pass each file's URL in the `fileUrl` parameter,",
-                " as returned in the `fileUrl` property from the [`getFileInfo()`](#getFileInfo),",
-                " [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions." ],
+                " Pass the file's URL in the `fileUrl` parameter,",
+                " as returned in the `fileUrl` property from the [`importFile()`](#importFile), [`upload()`](#upload), and [`listFiles()`](#listFiles) functions." ],
             "links": [],
             "examples":
               [ { "title": "Get a file's information",
@@ -621,8 +621,7 @@
         "extra":
           {  } },
       { "name": "getVideoPlaybackUrl",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",

--- a/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
+++ b/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
@@ -21,7 +21,8 @@
   "properties": [],
   "operations":
     [ { "name": "downloadFiles",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "fileUrls",
@@ -44,6 +45,9 @@
             "description":
               [ "The `downloadFiles()` function returns a Promise that resolves to a download URL ",
                 " for the specified file(s).",
+                "",
+                " Pass each file's URL in the `fileUrl` parameter, as returned ",
+                " in the `fileUrl` property of the `getFileInfo`, `importFile()`, `upload()`, and `listFiles()` functions.",
                 "",
                 " A compressed file is created and can be downloaded using the download URL. The compressed ",
                 " file can contain up to 1000 files.",
@@ -298,7 +302,8 @@
         "extra":
           {  } },
       { "name": "getFileInfo",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",
@@ -317,7 +322,10 @@
           { "summary": "Gets a file's information from the Media Manager by `fileUrl`.",
             "description":
               [ "The `getFileInfo()` function returns a Promise that resolves to information about",
-                " the specified file." ],
+                " the specified file. ",
+                " ",
+                " Pass the file's URL in the `fileUrl` parameter, as returned ",
+                " in the `fileUrl` property of the `importFile()`, `upload()`, and `listFiles()` functions." ],
             "links": [],
             "examples":
               [ { "title": "Get a file's information",
@@ -612,7 +620,8 @@
         "extra":
           {  } },
       { "name": "getVideoPlaybackUrl",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",
@@ -634,7 +643,10 @@
           { "summary": "Gets a video file's playback URL from the Media Manager.",
             "description":
               [ "The `getVideoPlaybackUrl()` function returns a Promise that resolves to the",
-                " specified video file's playback URL." ],
+                " specified video file's playback URL.",
+                "",
+                " Pass the file's URL in the `fileUrl` parameter, as returned ",
+                " in the `fileUrl` property of the `getFileInfo`, `importFile()`, `upload()`, and `listFiles()` functions." ],
             "links": [],
             "examples":
               [ { "title": "Get a URL to be used for video playback",
@@ -655,7 +667,8 @@
         "extra":
           {  } },
       { "name": "importFile",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "path",
@@ -717,7 +730,7 @@
                       "/* Returns a promise that resolves to:",
                       " *",
                       " * {",
-                      " *   \"fileUrl\": \"media/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg\",",
+                      " *   \"fileUrl\": \"wix:image://v1/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg/original-name.jpg#originWidth=300&originHeight=300\",",
                       " *   \"hash\": \"Ew00kXbu4Zt33rzjcWa6Ng==\",",
                       " *   \"sizeInBytes\": 51085,",
                       " *   \"mimeType\": \"image/jpeg\",",
@@ -1150,7 +1163,8 @@
         "extra":
           {  } },
       { "name": "moveFilesToTrash",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "fileUrls",
@@ -1173,6 +1187,9 @@
             "description":
               [ "The `moveFilesToTrash()` function returns a Promise that resolves when the file(s) are ",
                 " moved to the Media Manager's trash.",
+                "",
+                " Pass each file's URL in the `fileUrl` parameter, as returned ",
+                " in the `fileUrl` property of the `getFileInfo`, `importFile()`, `upload()`, and `listFiles()` functions.",
                 "",
                 " Moving many files to trash at once is an asynchronous action. It may take some time",
                 " for the results to be seen in the Media Manager.",
@@ -1967,7 +1984,7 @@
                       "/* Returns a promise that resolves to:",
                       " *",
                       " * {",
-                      " *   \"fileUrl\": \"media/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg\",",
+                      " *   \"fileUrl\": \"wix:image://v1/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg/original-name.jpg#originWidth=300&originHeight=300\",",
                       " *   \"hash\": \"Ew00kXbu4Zt33rzjcWa6Ng==\",",
                       " *   \"sizeInBytes\": 51085,",
                       " *   \"mimeType\": \"image/jpeg\",",
@@ -2045,7 +2062,8 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "MetadataOptions",
         "locations":
           [ { "lineno": 70,
@@ -2132,7 +2150,7 @@
                       "/* Returns a promise that resolves to:",
                       " *",
                       " * {",
-                      " *   \"fileUrl\": \"media/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg\",",
+                      " *   \"fileUrl\": \"wix:image://v1/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg/original-name.jpg#originWidth=300&originHeight=300\",",
                       " *   \"hash\": \"Ew00kXbu4Zt33rzjcWa6Ng==\",",
                       " *   \"sizeInBytes\": 51085,",
                       " *   \"mimeType\": \"image/jpeg\",",
@@ -2218,7 +2236,8 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "PaginationOptions",
         "locations":
           [ { "lineno": 47,
@@ -2308,8 +2327,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "UploadOptions",
         "locations":
           [ { "lineno": 1,
@@ -2393,7 +2411,7 @@
                       "/* Returns a promise that resolves to:",
                       " *",
                       " * {",
-                      " *   \"fileUrl\": \"media/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg\",",
+                      " *   \"fileUrl\": \"wix:image://v1/f6c0f9_tg439f4475a749e181dd14407fdbd37e~mv2.jpg/original-name.jpg#originWidth=300&originHeight=300\",",
                       " *   \"hash\": \"Ew00kXbu4Zt33rzjcWa6Ng==\",",
                       " *   \"sizeInBytes\": 51085,",
                       " *   \"mimeType\": \"image/jpeg\",",
@@ -2471,7 +2489,8 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "UploadUrl",
         "locations":
           [ { "lineno": 191,


### PR DESCRIPTION
…sue detected

changes:
Service wix-media-backend.MediaManager operation downloadFiles has changed description
Service wix-media-backend.MediaManager operation getFileInfo has changed description
Service wix-media-backend.MediaManager operation getVideoPlaybackUrl has changed description
Service wix-media-backend.MediaManager operation importFile.examples[0] has changed body
Service wix-media-backend.MediaManager operation moveFilesToTrash has changed description
Service wix-media-backend.MediaManager message MediaOptions.examples[1] has changed body
Service wix-media-backend.MediaManager message MetadataOptions.examples[1] has changed body
Service wix-media-backend.MediaManager message UploadOptions.examples[1] has changed body

issues:
Operation upload has an unknown param type Buffer (upload.js (1))
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating