### PR TITLE
Wix Pay Frontend - Broken Links fix

### DIFF
--- a/wix-pay-frontend/wix-pay-frontend.service.json
+++ b/wix-pay-frontend/wix-pay-frontend.service.json
@@ -1,6 +1,7 @@
 { "name": "wix-pay-frontend",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 1,
       "filename": "pay.js" },
@@ -21,16 +22,16 @@
           " 1. The button's event handler calls a backend function.",
           " 1. A `PaymentInfo` object containing information about",
           "    the payment, such as the payment amount, is created in the backend function.",
-          " 1. The backend function calls [`createPayment()`](wix-pay-backend.html#createPayment) using the",
+          " 1. The backend function calls [`createPayment()`](wix-pay-backend/create-payment) using the",
           "    `PaymentInfo` object and returns the generated",
           "    `Payment` object to the calling client-side event handler.",
-          " 1. The event handler then calls the [`startPayment()`](wix-pay-frontend.html#startPayment)",
+          " 1. The event handler then calls the [`startPayment()`](wix-pay-frontend/start-payment)",
           "    function with the id from the `Payment` object, which opens",
           "    the payment popup on your site.",
           " 1. The site visitor enters the payment information.",
           " 1. The event handler optionally handles the returned `PaymentResult`.",
           " 1. Handle additional status updates to the payment transaction using the",
-          "    [`onPaymentUpdate()`](wix-pay-backend.Events.html#onPaymentUpdate) event.",
+          "    [`onPaymentUpdate()`](wix-pay-backend/events/on-payment-update) event.",
           "",
           " To use the Pay API, import `wixPayFrontend` from the `wix-pay-frontend` module:",
           "",
@@ -46,7 +47,8 @@
         {  } },
   "properties":
     [ { "name": "currencies",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "get": true,
         "set": false,
         "type": "wix-pay-frontend.Currencies",
@@ -66,17 +68,17 @@
                 " The currency API contains the following objects:",
                 "",
                 " + Currencies",
-                "\t  - Use [`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) to get a list of all the convertible currencies.",
+                "\t  - Use [`getAllCurrencies()`](wix-pay-frontend/currencies/get-all-currencies) to get a list of all the convertible currencies.",
                 "",
                 "",
                 " + CurrencyConverter",
-                "  - Use [`convertAmounts()`](wix-pay-frontend.Currencies.CurrencyConverter.html#convertAmounts) to convert amounts between two currencies.",
-                "   - Use [`getConversionRate()`](wix-pay-frontend.Currencies.CurrencyConverter.html#getConversionRate) to get today’s conversion rate for a pair of currencies.  ",
+                "  - Use [`convertAmounts()`](wix-pay-frontend/currencies/currency-converter/convert-amounts) to convert amounts between two currencies.",
+                "   - Use [`getConversionRate()`](wix-pay-frontend/currencies/currency-converter/get-conversion-rate) to get today’s conversion rate for a pair of currencies.  ",
                 "",
                 "",
                 " + SiteSettings",
-                "   - Set the currencies to appear in your currency conversion dropdown using the backend function [`setCurrencies()`](wix-pay-backend.Currencies.SiteSettings.html#setCurrencies).",
-                "   - Use [`getCurrencies()`](wix-pay-frontend.Currencies.SiteSettings.html#getCurrencies) to see the list of the currencies that you set.",
+                "   - Set the currencies to appear in your currency conversion dropdown using the backend function [`setCurrencies()`](https://dev.wix.com/docs/velo/api-reference/wix-pay-backend/currencies/site-settings/set-currencies).",
+                "   - Use [`getCurrencies()`](wix-pay-frontend/currencies/site-settings/get-currencies) to see the list of the currencies that you set.",
                 "",
                 "   ",
                 "",
@@ -95,7 +97,8 @@
           {  } } ],
   "operations":
     [ { "name": "startPayment",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "paymentId",
@@ -124,15 +127,15 @@
                 "",
                 " The `startPayment()` function returns a Promise that resolves to a `PaymentResult`",
                 " object when the user completes the payment process. Only use this result for display purposes.",
-                " For business decisions, such as updating collection data, use the [`onPaymentUpdate`](wix-pay-backend.Events.html#onPaymentUpdate)",
+                " For business decisions, such as updating collection data, use the [`onPaymentUpdate`](wix-pay-backend/events/on-payment-update)",
                 " event.",
                 "",
                 " Starting a payment prompts the user to select a payment method and continue the",
                 " payment process with the options specified in the `options` parameter.",
                 "",
-                " Before calling `startPayment()`, create a payment and generate a value for the `paymentId` parameter. You can do this by calling [`createPayment()`](wix-pay-backend.html#createPayment) from your site's backend.",
+                " Before calling `startPayment()`, create a payment and generate a value for the `paymentId` parameter. You can do this by calling [`createPayment()`](wix-pay-backend/create-payment) from your site's backend.",
                 " ",
-                " <!-- + Calling [`createPayment()`](wix-pay-backend.html#createPayment) from your site's backend.",
+                " <!-- + Calling [`createPayment()`](wix-pay-backend/create-payment) from your site's backend.",
                 " + Calling a function from a different app, such as the Wix Pricing Plans' [`createOnlineOrder()`](wix-pricing-plans.html#createOnlineOrder) function.-->",
                 "",
                 " To understand how `startPayment()` is used in a typical payment lifecycle,",
@@ -147,7 +150,7 @@
                 "> **Notes:**",
                 "> + To work with the Pay API, you need to save and publish your site.",
                 ">",
-                "> + The backend [`createPayment()`](wix-pay-backend.html#createPayment) function",
+                "> + The backend [`createPayment()`](wix-pay-backend/create-payment) function",
                 ">   takes a `PaymentInfo` parameter that defines the information for a payment.",
                 ">   For security reasons you should always create the `PaymentInfo` object",
                 ">   in backend code. Do not pass payment information from client-side code.",
@@ -443,7 +446,7 @@
         "docs":
           { "summary": "An object representing a payment.",
             "links":
-              [ "[startPayment( )](wix-pay-frontend.html#startPayment)" ],
+              [ "[startPayment( )](wix-pay-frontend/start-payment)" ],
             "examples": [],
             "extra":
               {  } },
@@ -465,7 +468,8 @@
               "doc": "Payment items." } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "PaymentItem",
         "locations":
           [ { "lineno": 76,
@@ -496,7 +500,7 @@
         "docs":
           { "summary": "An object representing the options of a payment.",
             "links":
-              [ "[startPayment( )](wix-pay-frontend.html#startPayment)" ],
+              [ "[startPayment( )](wix-pay-frontend/start-payment)" ],
             "examples": [],
             "extra":
               {  } },
@@ -511,15 +515,16 @@
               "optional": true },
             { "name": "skipUserInfoPage",
               "type": "boolean",
-              "doc": "Whether to skip the user info page. Defaults to `false`.\n The page will be skipped only if user info was passed to [`createPayment()`](wix-pay-backend.html#createPayment) as\n a part of the `PaymentInfo` object.",
+              "doc": "Whether to skip the user info page. Defaults to `false`.\n The page will be skipped only if user info was passed to [`createPayment()`](wix-pay-backend/create-payment) as\n a part of the `PaymentInfo` object.",
               "optional": true },
             { "name": "userInfo",
               "type": "wix-pay-frontend.PaymentUserInfo",
-              "doc": "An object representing information about the user. It will be used to prefill\n user info form during payment process.\n\n Deprecation note: Pass user information to [`createPayment( )`](wix-pay-backend.html#createPayment) instead.",
+              "doc": "An object representing information about the user. It will be used to prefill\n user info form during payment process.\n\n Deprecation note: Pass user information to [`createPayment( )`](wix-pay-backend/create-payment) instead.",
               "optional": true } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "PaymentResult",
         "locations":
           [ { "lineno": 43,
@@ -527,7 +532,7 @@
         "docs":
           { "summary": "An object representing a payment result.",
             "links":
-              [ "[startPayment( )](wix-pay-frontend.html#startPayment)" ],
+              [ "[startPayment( )](wix-pay-frontend/start-payment)" ],
             "examples": [],
             "extra":
               {  } },
@@ -546,7 +551,8 @@
               "doc": "An object representing information about the user." } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "PaymentUserInfo",
         "locations":
           [ { "lineno": 102,
@@ -554,7 +560,7 @@
         "docs":
           { "summary": "An object representing information about the user.",
             "links":
-              [ "[startPayment( )](wix-pay-frontend.html#startPayment)" ],
+              [ "[startPayment( )](wix-pay-frontend/start-payment)" ],
             "examples": [],
             "extra":
               {  } },
@@ -576,7 +582,8 @@
               "doc": "User's email address. Value is `null` if\n there is no email address information." } ],
         "extra":
           {  },
-        "labels": [] } ],
+        "labels":
+          [ "changed" ] } ],
   "extra":
     { "scopes":
         [ "frontend" ] } }

--- a/wix-pay-frontend/wix-pay-frontend/Currencies.service.json
+++ b/wix-pay-frontend/wix-pay-frontend/Currencies.service.json
@@ -1,7 +1,8 @@
 { "name": "Currencies",
   "memberOf": "wix-pay-frontend",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 1,
       "filename": "currencies.js" },
@@ -17,17 +18,17 @@
           " The currency API contains the following objects:",
           "",
           " + Currencies",
-          "\t  - Use [`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) to get a list of all the convertible currencies.",
+          "\t  - Use [`getAllCurrencies()`](wix-pay-frontend/currencies/get-all-currencies) to get a list of all the convertible currencies.",
           "",
           "",
           " + CurrencyConverter",
-          "   - Use [`convertAmounts()`](https://dev.wix.com/docs/velo/api-reference/wix-pay-frontend/currencies/currency-converter/convert-amounts) to convert amounts between two currencies.",
-          "   - Use [`getConversionRate()`](wix-pay-frontend.Currencies.CurrencyConverter.html#getConversionRate) to get today’s conversion rate for a pair of currencies.  ",
+          "   - Use [`convertAmounts()`](wix-pay-frontend/currencies/currency-converter/convert-amounts) to convert amounts between two currencies.",
+          "   - Use [`getConversionRate()`](wix-pay-frontend/currencies/currency-converter/get-conversion-rate) to get today’s conversion rate for a pair of currencies.  ",
           "",
           "",
           " + SiteSettings",
-          "   - Set the currencies to appear in your currency conversion dropdown using the backend function [`setCurrencies()`](wix-pay-backend.Currencies.SiteSettings.html#setCurrencies).",
-          "   - Use [`getCurrencies()`](https://dev.wix.com/docs/velo/api-reference/wix-pay-frontend/currencies/site-settings/get-currencies) to see the list of the currencies that you set.",
+          "   - Set the currencies to appear in your currency conversion dropdown using the backend function [`setCurrencies()`](wix-pay-backend/currencies/site-settings/set-currencies).",
+          "   - Use [`getCurrencies()`](wix-pay-frontend/currencies/site-settings/get-currencies) to see the list of the currencies that you set.",
           "",
           "To use the Currencies API you must upgrade your site to a [Premium Plan](https://support.wix.com/en/article/upgrading-your-site-to-premium-3066683). ",
           "",
@@ -63,7 +64,8 @@
         "extra":
           {  } },
       { "name": "siteSettings",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "get": true,
         "set": false,
         "type": "wix-pay-frontend.Currencies.SiteSettings",
@@ -73,9 +75,9 @@
         "docs":
           { "summary": "Gets currencies that you set for your site.",
             "description":
-              [ "You can get the currencies that you set your site to support using the backend function [`siteSetting.setCurrencies()`](wix-pay-backend.Currencies.html#sitesettings.setcurrencies). These are the currencies that are displayed in the [currency conversion](https://support.wix.com/en/article/adding-and-setting-up-a-currency-converter-in-wix-stores) element and used to convert currencies in your Wix Store.",
+              [ "You can get the currencies that you set your site to support using the backend function [`siteSetting.setCurrencies()`](wix-pay-backend/currencies/site-settings/set-currencies). These are the currencies that are displayed in the [currency conversion](https://support.wix.com/en/article/adding-and-setting-up-a-currency-converter-in-wix-stores) element and used to convert currencies in your Wix Store.",
                 "",
-                "The currency codes used must exist in the array returned by the [`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) function.",
+                "The currency codes used must exist in the array returned by the [`getAllCurrencies()`](wix-pay-frontend/currencies/get-all-currencies) function.",
                 "> **Note:**  ",
                 "For SiteSettings functions to work, your site must contain a Wix Stores page including the [currency conversion element](https://support.wix.com/en/article/adding-and-setting-up-a-currency-converter-in-wix-stores)." ],
             "links": [],
@@ -86,7 +88,8 @@
           {  } } ],
   "operations":
     [ { "name": "getAllCurrencies",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params": [],
         "ret":
@@ -105,8 +108,8 @@
             "description":
               [ "The `getAllCurrencies()` function returns a Promise that resolves to an array of currencies. ",
                 "The array lists all currencies for which Wix supports conversion and their symbols.",
-                "> **Note:** The `getAllCurrencies()` function is different from [`siteSettings.getCurrencies()`](wix-pay-frontend.Currencies.SiteSettings.html#getCurrencies) in that this function gets the complete list of all of the currencies that are supported on Wix sites. ",
-                "The [`siteSettings.getCurrencies()`](wix-pay-frontend.Currencies.SiteSettings.html#getCurrencies) function gets only the currencies that have been set for use in your site using the backend function [`siteSettings.setCurrencies()`](wix-pay-backend.Currencies.SiteSettings.html#setCurrencies)." ],
+                "> **Note:** The `getAllCurrencies()` function is different from [`siteSettings.getCurrencies()`](wix-pay-frontend/currencies/site-settings/get-currencies) in that this function gets the complete list of all of the currencies that are supported on Wix sites. ",
+                "The [`siteSettings.getCurrencies()`](wix-pay-frontend/currencies/site-settings/get-currencies) function gets only the currencies that have been set for use in your site using the backend function [`siteSettings.setCurrencies()`](wix-pay-backend/Currencies.Site-Settings/set-Currencies)." ],
             "links": [],
             "examples":
               [ { "title": "Get all supported currencies",

--- a/wix-pay-frontend/wix-pay-frontend/Currencies/CurrencyConverter.service.json
+++ b/wix-pay-frontend/wix-pay-frontend/Currencies/CurrencyConverter.service.json
@@ -1,7 +1,8 @@
 { "name": "CurrencyConverter",
   "memberOf": "wix-pay-frontend.Currencies",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 112,
       "filename": "currencies.js" },
@@ -17,7 +18,8 @@
   "properties": [],
   "operations":
     [ { "name": "convertAmounts",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "options",
@@ -39,7 +41,7 @@
                 "The `convertAmounts()` function returns a Promise that resolves to a `ConvertedAmounts` object which contains an array of converted amounts and the timestamp for the conversion rate used. ",
                 "> **Note:**",
                 "The currency codes used must exist in the array returned by the ",
-                "[`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) function." ],
+                "[`getAllCurrencies()`](wix-pay-frontend/Currencies/get-All-Currencies) function." ],
             "links": [],
             "examples":
               [ { "title": "Convert an array of amounts from one currency to another.",
@@ -159,13 +161,14 @@
               "doc": "Amounts to convert." },
             { "name": "from",
               "type": "string",
-              "doc": "Currency to convert from.  The `from` currency code used must exist in the array returned by the [`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) function." },
+              "doc": "Currency to convert from.  The `from` currency code used must exist in the array returned by the [`getAllCurrencies()`](wix-pay-frontend/Currencies/get-All-Currencies) function." },
             { "name": "to",
               "type": "string",
-              "doc": "Currency to convert to. The `to` currency code used must exist in the array returned by the [`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) function.\n> **Note:**\nThe `from` and `to` currency codes used must exist in the array returned by the \n[`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) function." } ],
+              "doc": "Currency to convert to. The `to` currency code used must exist in the array returned by the [`getAllCurrencies()`](wix-pay-frontend/currencies/get-all-currencies) function.\n> **Note:**\nThe `from` and `to` currency codes used must exist in the array returned by the \n[`getAllCurrencies()`](wix-pay-frontend/currencies/get-all-currencies) function." } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "ConvertedAmounts",
         "locations":
           [ { "lineno": 159,

--- a/wix-pay-frontend/wix-pay-frontend/Currencies/SiteSettings.service.json
+++ b/wix-pay-frontend/wix-pay-frontend/Currencies/SiteSettings.service.json
@@ -1,14 +1,15 @@
 { "name": "SiteSettings",
   "memberOf": "wix-pay-frontend.Currencies",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 179,
       "filename": "currencies.js" },
   "docs":
     { "summary": "Site-related currency settings.",
       "description":
-        [ "You can get the currencies that you set for your site using the backend function [`siteSetting.setCurrencies()`](wix-pay-backend.Currencies.html#sitesettings.setcurrencies). These are the currencies that are displayed in the [currency conversion](https://support.wix.com/en/article/adding-and-setting-up-a-currency-converter-in-wix-stores) element and used to convert currencies in your Wix Store.",
+        [ "You can get the currencies that you set for your site using the backend function [`siteSetting.setCurrencies()`](wix-pay-backend/currencies/site-settings/set-currencies). These are the currencies that are displayed in the [currency conversion](https://support.wix.com/en/article/adding-and-setting-up-a-currency-converter-in-wix-stores) element and used to convert currencies in your Wix Store.",
           "> **Note:**",
           "> For SiteSettings functions to work, your site must contain a Wix Stores page including the [currency conversion element](https://support.wix.com/en/article/adding-and-setting-up-a-currency-converter-in-wix-stores)." ],
       "links": [],
@@ -18,7 +19,8 @@
   "properties": [],
   "operations":
     [ { "name": "getCurrencies",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params": [],
         "ret":
@@ -35,10 +37,10 @@
         "docs":
           { "summary": "Gets the list of supported currencies that you set for your site.",
             "description":
-              [ "The `getCurrencies()` function returns a Promise that resolves to an array of currencies that were set for use in the site using the backend function [`siteSetting.setCurrencies()`](wix-pay-backend.Currencies.SiteSettings.html#setCurrencies). ",
-                "This function is different from the [`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) function in that it gets only the currencies that have",
-                "been set for use in  this site using the [`siteSetting.setCurrencies()`](wix-pay-backend.Currencies.SiteSettings.html#setCurrencies) function.",
-                "The [`getAllCurrencies()`](wix-pay-frontend.Currencies.html#getAllCurrencies) function gets the complete list of all of the currencies that can be supported. ",
+              [ "The `getCurrencies()` function returns a Promise that resolves to an array of currencies that were set for use in the site using the backend function [`siteSetting.setCurrencies()`](wix-pay-backend/currencies/site-settings/set-currencies). ",
+                "This function is different from the [`getAllCurrencies()`](wix-pay-frontend/currencies/get-all-currencies) function in that it gets only the currencies that have",
+                "been set for use in  this site using the [`siteSetting.setCurrencies()`](wix-pay-backend/currencies/site-settings/set-currencies) function.",
+                "The [`getAllCurrencies()`](wix-pay-frontend/currencies/get-all-currencies) function gets the complete list of all of the currencies that can be supported. ",
                 "> **Note:**",
                 "For SiteSettings functions to work, your site must contain a Wix Stores page including the [currency conversion element](https://support.wix.com/en/article/adding-and-setting-up-a-currency-converter-in-wix-stores)." ],
             "links": [],


### PR DESCRIPTION
changes:
Service wix-pay-frontend.Currencies.CurrencyConverter operation convertAmounts has changed description Service wix-pay-frontend.Currencies.CurrencyConverter message ConvertAmountsOptions member from has changed doc Service wix-pay-frontend.Currencies.CurrencyConverter message ConvertAmountsOptions member to has changed doc Service wix-pay-frontend.Currencies.SiteSettings has changed description Service wix-pay-frontend.Currencies.SiteSettings operation getCurrencies has changed description Service wix-pay-frontend.Currencies has changed description Service wix-pay-frontend.Currencies property siteSettings has changed description Service wix-pay-frontend.Currencies operation getAllCurrencies has changed description Service wix-pay-frontend has changed description
Service wix-pay-frontend property currencies has changed description Service wix-pay-frontend operation startPayment has changed description Service wix-pay-frontend message Payment has a new link [startPayment( )](wix-pay-frontend/start-payment) Service wix-pay-frontend message Payment link [startPayment( )](wix-pay-frontend.html#startPayment) was removed Service wix-pay-frontend message PaymentOptions member skipUserInfoPage has changed doc Service wix-pay-frontend message PaymentOptions member userInfo has changed doc Service wix-pay-frontend message PaymentOptions has a new link [startPayment( )](wix-pay-frontend/start-payment) Service wix-pay-frontend message PaymentOptions link [startPayment( )](wix-pay-frontend.html#startPayment) was removed Service wix-pay-frontend message PaymentResult has a new link [startPayment( )](wix-pay-frontend/start-payment) Service wix-pay-frontend message PaymentResult link [startPayment( )](wix-pay-frontend.html#startPayment) was removed Service wix-pay-frontend message PaymentUserInfo has a new link [startPayment( )](wix-pay-frontend/start-payment) Service wix-pay-frontend message PaymentUserInfo link [startPay ...