### PR TITLE
DocWorks for editor-elements - 1 change detected, but 134 issue detected

### DIFF
--- a/editor-elements/$w/Breadcrumbs.service.json
+++ b/editor-elements/$w/Breadcrumbs.service.json
@@ -3,7 +3,8 @@
   "mixes":
     [ "$w.HiddenCollapsedMixin",
       "$w.ViewportMixin" ],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 1,
       "filename": "Breadcrumbs.js" },
@@ -71,7 +72,8 @@
         "extra":
           {  } },
       { "name": "items",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "get": true,
         "set": true,
         "type":
@@ -95,7 +97,7 @@
                 " Getting the `items` property returns breadcrumbs items that have been set using code. If no",
                 " items have been set using code, your site generates a default items array based on your home page, the site visitor's location, ",
                 " and the organization of your site's pages including ",
-                " any [menu folders](https://support.wix.com/en/article/wix-editor-creating-and-managing-a-dropdown-submenu) you have added to your site. ",
+                " any [menu folders](https://support.wix.com/en/article/studio-editor-managing-dropdowns-in-a-menu#adding-items-to-a-dropdown-menu) you have added to your site. ",
                 "",
                 " Properties that don't have a value are omitted from the returned array.",
                 "",

--- a/editor-elements/$w/Section.service.json
+++ b/editor-elements/$w/Section.service.json
@@ -8,8 +8,7 @@
       "$w.ContainableMixin",
       "$w.EffectsMixin",
       "$w.StyleMixin" ],
-  "labels":
-    [ "changed" ],
+  "labels": [],
   "location":
     { "lineno": 1,
       "filename": "Section.js" },
@@ -30,8 +29,7 @@
         {  } },
   "properties":
     [ { "name": "style",
-        "labels":
-          [ "new" ],
+        "labels": [],
         "get": true,
         "set": false,
         "type": "$w.Style",


### PR DESCRIPTION
changes:
Service $w.Breadcrumbs property items has changed description

issues:
Mixin $w.HiddenCollapsedMixin not found (Breadcrumbs.js (1)) Mixin $w.ViewportMixin not found (Breadcrumbs.js (1)) Mixin $w.Element not found (CollapsibleTextBox.js (1)) Mixin $w.HiddenCollapsedMixin not found (CollapsibleTextBox.js (1)) Mixin $w.ClickableMixin not found (CollapsibleTextBox.js (1)) Property link has an unknown type null (DashboardButton.js (112)) Property target has an unknown type null (DashboardButton.js (118)) Property prefix has an unknown type null (DashboardButton.js (193)) Property suffix has an unknown type null (DashboardButton.js (224)) Property customClassList has an unknown type $w.CustomClassList (DashboardButton.js (252)) Property link has mismatching types for get (string) and set (string,null) (DashboardButton.js (66, 112)) Property target is defined two or more times (DashboardButton.js (118, 143)) Property rel is defined two or more times (DashboardButton.js (149, 186)) Property prefix has mismatching types for get (string,null) and set (string) (DashboardButton.js (193, 218)) Property suffix has mismatching types for get (string,null) and set (string) (DashboardButton.js (224, 246)) Mixin $w.ClickableMixin not found (DashboardButton.js (1)) Mixin $w.DisabledMixin not found (DashboardButton.js (1)) Mixin $w.HiddenCollapsedElement not found (DashboardButton.js (1)) Mixin $w.LinkableMixin not found (DashboardButton.js (1)) Property customClassList has an unknown type $w.CustomClassList (DashboardHeading.js (33)) Mixin $w.HiddenCollapsedElement not found (DashboardHeading.js (1)) Property target has an unknown type null (DashboardIconButton.js (124)) Property customClassList has an unknown type $w.CustomClassList (DashboardIconButton.js (199)) Property target has mismatching types for get (string,null) and set (string) (DashboardIconButton.js (124, 149)) Property rel is defined two or ...