### PR TITLE
DocWorks for wix-data-hooks - 5 changes detected, but 13 issue detected

### DIFF
--- a/wix-data-hooks/wix-data-hooks.service.json
+++ b/wix-data-hooks/wix-data-hooks.service.json
@@ -1,7 +1,7 @@
 { "name": "wix-data-hooks",
   "mixes": [],
   "labels":
-    [ "new" ],
+    [ "changed" ],
   "location":
     { "lineno": 20,
       "filename": "hooks-standalone.js" },
@@ -43,12 +43,13 @@
   "properties": [],
   "operations":
     [ { "name": "afterAggregate",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "item",
               "type": "Object",
-              "doc": "The aggregation result item." },
+              "doc": "Aggregation result item." },
             { "name": "context",
               "type": "wix-data-hooks.HookContext",
               "doc": "Contextual information about the hook." } ],
@@ -58,7 +59,7 @@
                   "typeParams":
                     [ "Object" ] },
                 "Object" ],
-            "doc": "The item to return to [`aggregate()`](https://dev.wix.com/docs/velo/api-reference/wix-data/update) to replace the original aggregation result item.\n Returning a rejected promise returns a rejected promise to the caller and triggers the [`onFailure()`](#onFailure) hook without blocking the aggregation operation." },
+            "doc": "Item to return to [`aggregate()`](https://dev.wix.com/docs/velo/api-reference/wix-data/update) to replace the original aggregation result item.\n Returning a rejected promise returns a rejected promise to the caller and triggers the [`onFailure()`](#onFailure) hook without blocking the aggregation operation." },
         "locations":
           [ { "lineno": 55,
               "filename": "hooks-standalone.js" } ],
@@ -215,6 +216,52 @@
               {  } },
         "extra":
           {  } },
+      { "name": "afterDistinct",
+        "labels":
+          [ "new" ],
+        "nameParams": [],
+        "params":
+          [ { "name": "item",
+              "type": "Object",
+              "doc": "Distinct query result item." },
+            { "name": "context",
+              "type": "wix-data-hooks.HookContext",
+              "doc": "Contextual information about the hook." } ],
+        "ret":
+          { "type":
+              [ { "name": "Promise",
+                  "typeParams":
+                    [ "Object" ] },
+                "Object" ],
+            "doc": "Item to return to [`distinct()`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query/distinct) to replace the original distinct query result item." },
+        "locations":
+          [ { "lineno": 109,
+              "filename": "hooks-standalone.js" } ],
+        "docs":
+          { "summary": "A hook triggered after a distinct query operation.",
+            "description":
+              [ "The `afterDistinct()` hook allows you to modify the results of the distinct query before they are returned to the caller. The hook runs for each item in the `items` array within the [WixDataQueryResult](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query-result/introduction) object, after the distinct query operation finishes and before the [`distinct()`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query/distinct) method returns.",
+                "",
+                "Return an object or a Promise that resolves to an object. If the returned value is of the wrong type, it is ignored.",
+                "",
+                "If returning a Promise, the object is used as the result regardless of whether the Promise is fulfilled or rejected. A rejected Promise also triggers the [`onFailure()`](#onFailure) hook, if it has been registered." ],
+            "links": [],
+            "examples":
+              [ { "title": "An `afterDistinct()` hook",
+                  "body":
+                    [ "// An `afterDistinct()` hook",
+                      "//" ],
+                  "extra":
+                    {  } },
+                { "title": "Modify the item returned by `distinct()` using an `afterDistinct()` hook",
+                  "body":
+                    [ "// Modify the item returned by `distinct()` using an `afterDistinct()` hook." ],
+                  "extra":
+                    {  } } ],
+            "extra":
+              {  } },
+        "extra":
+          {  } },
       { "name": "afterGet",
         "labels": [],
         "nameParams": [],
@@ -233,7 +280,7 @@
                 "Object" ],
             "doc": "The item to return to [`get()`](wix-data.html#get) instead of the retrieved item.\n Returning a rejected promise will not block the operation, but will return a rejected promise to the operation caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 109,
+          [ { "lineno": 131,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered after a `get()` operation.",
@@ -326,7 +373,7 @@
                 "Object" ],
             "doc": "The item to return to [`insert()`](wix-data.html#insert) instead of the inserted item.\n Returning a rejected promise will not block the operation, but will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 141,
+          [ { "lineno": 163,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered after an `insert()` operation.",
@@ -424,7 +471,7 @@
                 "Object" ],
             "doc": "The item to return to [`find`](wix-data.WixDataQuery.html#find) instead of the item retrieved from the database.\n Returning a rejected promise will not block the operation, but will return a rejected promise to the operation caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 178,
+          [ { "lineno": 200,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered after a `find` operation, for each of the items in the query results.",
@@ -524,7 +571,7 @@
                 "Object" ],
             "doc": "The item to return to [`remove()`](wix-data.html#remove) instead of the deleted item.\n Returning a rejected promise will not block the operation, but will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 218,
+          [ { "lineno": 240,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered after a `remove()` operation.",
@@ -620,7 +667,7 @@
                 "Object" ],
             "doc": "The item to return to [`update()`](https://dev.wix.com/docs/velo/api-reference/wix-data/update) instead of the updated item.\n Returning a rejected promise will not block the operation, but will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 253,
+          [ { "lineno": 275,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered after an `update()` operation.",
@@ -701,6 +748,91 @@
               {  } },
         "extra":
           {  } },
+      { "name": "beforeAggregate",
+        "labels":
+          [ "new" ],
+        "nameParams": [],
+        "params":
+          [ { "name": "aggregate",
+              "type": "wix-data.WixDataAggregate",
+              "doc": "Original `WixDataAggregate` object." },
+            { "name": "context",
+              "type": "wix-data-hooks.HookContext",
+              "doc": "Contextual information about the hook." } ],
+        "ret":
+          { "type":
+              [ { "name": "Promise",
+                  "typeParams":
+                    [ "wix-data.WixDataAggregate" ] },
+                "wix-data.WixDataAggregate" ],
+            "doc": "The aggregate object to run instead of the original object created by the `aggregate()` method.\n Returning a rejected promise blocks the operation, returns a rejected promise to the caller, and triggers the [`onFailure()`](#onFailure) hook." },
+        "locations":
+          [ { "lineno": 348,
+              "filename": "hooks-standalone.js" } ],
+        "docs":
+          { "summary": "A hook triggered before an aggregation operation.",
+            "description":
+              [ "The `beforeAggregate()` hook runs when the [`aggregate()`](https://dev.wix.com/docs/velo/api-reference/wix-data/aggregate) is called, and allows you to modify the [`WixDataAggregate`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-aggregate/introduction) object before the aggregation operation runs.",
+                "",
+                "",
+                " Return a [WixDataAggregate](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-aggregate/introduction) object or a Promise that resolves to a [WixDataAggregate](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-aggregate/introduction) object. The returned object is the aggregation that runs on the collection instead of the original aggregation created by the [`aggregate()`](https://dev.wix.com/docs/velo/api-reference/wix-data/aggregate) method.",
+                "",
+                " If the returned value is of the wrong type, the value is ignored.",
+                "",
+                " A rejected Promise blocks the call to [`aggregate()`](https://dev.wix.com/docs/velo/api-reference/wix-data/aggregate) and triggers the [`onFailure()`](#onFailure) hook, if it has been registered." ],
+            "links": [],
+            "examples":
+              [ { "title": "A `beforeAggregate` hook",
+                  "body":
+                    [ "// In data.js",
+                      "",
+                      "export function myCollection_beforeAggregate(aggregate, context) {",
+                      "  let hookContext = context; // see below",
+                      "",
+                      "  // Some modification to the WixDataAggregate object.",
+                      "",
+                      "  return aggregate;",
+                      "}",
+                      "",
+                      "/*",
+                      " * hookContext:",
+                      " *",
+                      " * {",
+                      " *   \"collectionName\": \"myCollection\",",
+                      " *   \"userId\":         \"f45jf8d2-grkj-2opd-4ovk-9rfj4wo5tvj3\",",
+                      " *   \"userRole\":       \"siteOwner\"",
+                      " * }",
+                      " */" ],
+                  "extra":
+                    {  } },
+                { "title": "Change the `WixDataAggregate` object using a `beforeAggregate` hook",
+                  "body":
+                    [ "// In data.js",
+                      "",
+                      "export function myCollection_afterAggregate(aggregate, context) {",
+                      "  let hookContext = context; // see below",
+                      "",
+                      "  // Add a filter to the aggregation object.",
+                      "  let newAggregate = aggregate.filter().le(\"population\", 2000000);",
+                      "",
+                      "  return newAggregate;",
+                      "}",
+                      "",
+                      "/*",
+                      " * hookContext:",
+                      " *",
+                      " * {",
+                      " *   \"collectionName\": \"myCollection\",",
+                      " *   \"userId\":         \"f45jf8d2-grkj-2opd-4ovk-9rfj4wo5tvj3\",",
+                      " *   \"userRole\":       \"siteOwner\"",
+                      " * }",
+                      " */" ],
+                  "extra":
+                    {  } } ],
+            "extra":
+              {  } },
+        "extra":
+          {  } },
       { "name": "beforeCount",
         "labels": [],
         "nameParams": [],
@@ -719,7 +851,7 @@
                 "wix-data.WixDataQuery" ],
             "doc": "The `query` to be used for the [`count()`](wix-data.WixDataQuery.html#count) operation instead of the original query.\n Returning a rejected promise will block the operation and will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 291,
+          [ { "lineno": 313,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered before a `count()` operation.",
@@ -797,6 +929,55 @@
               {  } },
         "extra":
           {  } },
+      { "name": "beforeDistinct",
+        "labels":
+          [ "new" ],
+        "nameParams": [],
+        "params":
+          [ { "name": "distinctQuery",
+              "type": "wix-data.WixDataDistinct",
+              "doc": "Original `WixDataDistinct` object." },
+            { "name": "context",
+              "type": "wix-data-hooks.HookContext",
+              "doc": "Contextual information about the hook." } ],
+        "ret":
+          { "type":
+              [ { "name": "Promise",
+                  "typeParams":
+                    [ "wix-data.WixDataDistinct" ] },
+                "wix-data.WixDataDistinct" ],
+            "doc": "Distinct query object to run instead of the original object created by the `distinct()` method.\n Returning a rejected promise blocks the operation, returns a rejected promise to the caller, and triggers the [`onFailure()`](#onFailure) hook." },
+        "locations":
+          [ { "lineno": 372,
+              "filename": "hooks-standalone.js" } ],
+        "docs":
+          { "summary": "A hook triggered before a distinct query operation.",
+            "description":
+              [ "The `beforeDistinct()` hook runs when the [`distinct()`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query/distinct) is called. It allows you to modify the [`WixDataDistinct`](ADDLINK) object before the distinct query operation runs.",
+                "",
+                "Return a [`WixDataDistinct`](ADDLINK) object or a Promise that resolves to a [`WixDataDistinct`](ADDLINK) object. The returned object defines the distinct query operation that runs on the collection instead of the original operation created by the [`distinct()`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query/distinct) method.",
+                "",
+                "If the returned value is of the wrong type, the value is ignored.",
+                "",
+                "A rejected Promise blocks the call to [`distinct()`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query/distinct) and triggers the [`onFailure()`](#onFailure) hook, if it has been registered." ],
+            "links": [],
+            "examples":
+              [ { "title": "A `beforeDistinct` hook",
+                  "body":
+                    [ "// A `beforeDistinct` hook",
+                      "//" ],
+                  "extra":
+                    {  } },
+                { "title": "Refine the `WixDataDistinct` object",
+                  "body":
+                    [ "// Refine the `WixDataDistinct` object",
+                      "//" ],
+                  "extra":
+                    {  } } ],
+            "extra":
+              {  } },
+        "extra":
+          {  } },
       { "name": "beforeGet",
         "labels": [],
         "nameParams": [],
@@ -815,7 +996,7 @@
                 "string" ],
             "doc": "The ID to be used for the [`get()`](wix-data.html#get) operation instead of the original `itemId` specified by the caller.\n Returning a rejected promise will block the operation and will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 326,
+          [ { "lineno": 395,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered before a `get()` operation.",
@@ -911,7 +1092,7 @@
                 "Object" ],
             "doc": "The item to be inserted instead of the original item specified by the caller.\n Returning a rejected promise will block the operation and will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 361,
+          [ { "lineno": 430,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered before an `insert()` operation.",
@@ -1044,7 +1225,7 @@
                 "wix-data.WixDataQuery" ],
             "doc": "The query to use instead of the original query specified by the caller.\n Returning a rejected promise will block the operation and will return a rejected promise to the operation caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 400,
+          [ { "lineno": 469,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered before a `find()` operation.",
@@ -1146,7 +1327,7 @@
                 "string" ],
             "doc": "The ID to be used for the [`remove()`](wix-data.html#remove) instead of the original `itemId` specified by the caller.\n Returning a rejected promise will block the operation and will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 441,
+          [ { "lineno": 510,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is called before a `remove()` operation.",
@@ -1245,7 +1426,7 @@
                 "Object" ],
             "doc": "The item to be updated instead of the original item specified by the caller.\n Returning a rejected promise will block the operation and will return a rejected promise to the caller as well as trigger the [`onFailure()`](#onFailure) hook." },
         "locations":
-          [ { "lineno": 479,
+          [ { "lineno": 548,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered before an `update()` operation.",
@@ -1348,7 +1529,7 @@
                   [ "Object" ] },
             "doc": "Fulfilled - Returning a fulfilled promise will result in a fulfilled data operation with the provided result.\nRejected - Returning a rejected promise will result in returning a rejected promise to the caller of the data operation." },
         "locations":
-          [ { "lineno": 516,
+          [ { "lineno": 585,
               "filename": "hooks-standalone.js" } ],
         "docs":
           { "summary": "A hook that is triggered on any error or rejected Promise from any of the wix-data operations.",


### PR DESCRIPTION
changes:
Service wix-data-hooks operation afterAggregate has changed param item doc Service wix-data-hooks operation afterAggregate has changed return doc Service wix-data-hooks has a new operation afterDistinct Service wix-data-hooks has a new operation beforeAggregate Service wix-data-hooks has a new operation beforeDistinct

issues:
Operation beforeCount has an unknown param type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeCount has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeCount has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeAggregate has an unknown param type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeAggregate has an unknown return type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeAggregate has an unknown return type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeDistinct has an unknown param type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeDistinct has an unknown return type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeDistinct has an unknown return type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeQuery has an unknown param type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation beforeQuery has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation beforeQuery has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation onFailure has an unknown param type Error (hooks-standalone.js (585))