### PR TITLE
DocWorks for wix-data-hooks - no significant changes detected, but 13…

### DIFF
--- a/wix-data-hooks/wix-data-hooks.service.json
+++ b/wix-data-hooks/wix-data-hooks.service.json
@@ -1,7 +1,6 @@
 { "name": "wix-data-hooks",
   "mixes": [],
-  "labels":
-    [ "changed" ],
+  "labels": [],
   "location":
     { "lineno": 20,
       "filename": "hooks-standalone.js" },
@@ -216,8 +215,7 @@
         "extra":
           {  } },
       { "name": "afterDistinct",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "item",
@@ -964,8 +962,7 @@
         "extra":
           {  } },
       { "name": "beforeDistinct",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "distinct",


### PR DESCRIPTION
… issue detected

issues:
Operation beforeCount has an unknown param type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeCount has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeCount has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeAggregate has an unknown param type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeAggregate has an unknown return type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeAggregate has an unknown return type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeDistinct has an unknown param type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeDistinct has an unknown return type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeDistinct has an unknown return type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeQuery has an unknown param type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation beforeQuery has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation beforeQuery has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation onFailure has an unknown param type Error (hooks-standalone.js (585))