### PR TITLE
DocWorks for wix-data-hooks - 3 changes detected, but 13 issue detected

### DIFF
--- a/wix-data-hooks/wix-data-hooks.service.json
+++ b/wix-data-hooks/wix-data-hooks.service.json
@@ -1,6 +1,7 @@
 { "name": "wix-data-hooks",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 20,
       "filename": "hooks-standalone.js" },
@@ -42,11 +43,12 @@
   "properties": [],
   "operations":
     [ { "name": "afterAggregate",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "item",
-              "type": "Object",
+              "type": "any",
               "doc": "Aggregation result item." },
             { "name": "context",
               "type": "wix-data-hooks.HookContext",
@@ -55,8 +57,8 @@
           { "type":
               [ { "name": "Promise",
                   "typeParams":
-                    [ "Object" ] },
-                "Object" ],
+                    [ "any" ] },
+                "any" ],
             "doc": "Item to return to [`aggregate()`](https://dev.wix.com/docs/velo/api-reference/wix-data/update) to replace the original aggregation result item.\n Returning a rejected promise returns a rejected promise to the caller and triggers the [`onFailure()`](#onFailure) hook without blocking the aggregation operation." },
         "locations":
           [ { "lineno": 55,
@@ -215,7 +217,8 @@
         "extra":
           {  } },
       { "name": "afterDistinct",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "item",
@@ -237,9 +240,9 @@
         "docs":
           { "summary": "A hook triggered after a distinct query operation.",
             "description":
-              [ "The `afterDistinct()` hook allows you to modify the results of the distinct query before they are returned to the caller. The hook runs for each item in the `items` array within the [WixDataQueryResult](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query-result/introduction) object, after the distinct query operation finishes and before the [`distinct()`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query/distinct) method returns.",
+              [ "The `afterDistinct()` hook allows you to modify the results of the distinct query before they are returned to the caller. The hook runs for each distinct value in the `items` array within the [WixDataQueryResult](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query-result/introduction) object, after the distinct query operation finishes and before the [`distinct()`](https://dev.wix.com/docs/velo/api-reference/wix-data/wix-data-query/distinct) method returns.",
                 "",
-                "Return an object or a Promise that resolves to an object. If the returned value is of the wrong type, it is ignored.",
+                "Return an object or a Promise that resolves to a distinct item. If the returned value is of the wrong type, it is ignored.",
                 "",
                 "If returning a Promise, the object is used as the result regardless of whether the Promise is fulfilled or rejected. A rejected Promise also triggers the [`onFailure()`](#onFailure) hook, if it has been registered." ],
             "links": [],


### PR DESCRIPTION
changes:
Service wix-data-hooks operation afterAggregate has changed param item type Service wix-data-hooks operation afterAggregate has changed return type Service wix-data-hooks operation afterDistinct has changed description

issues:
Operation beforeCount has an unknown param type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeCount has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeCount has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (313)) Operation beforeAggregate has an unknown param type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeAggregate has an unknown return type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeAggregate has an unknown return type wix-data.WixDataAggregate (hooks-standalone.js (348)) Operation beforeDistinct has an unknown param type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeDistinct has an unknown return type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeDistinct has an unknown return type wix-data.WixDataDistinct (hooks-standalone.js (372)) Operation beforeQuery has an unknown param type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation beforeQuery has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation beforeQuery has an unknown return type wix-data.WixDataQuery (hooks-standalone.js (469)) Operation onFailure has an unknown param type Error (hooks-standalone.js (585))