### PR TITLE
feat(seo): WIXSEO-3896 expose additive SEO APIs

### DIFF
--- a/wix-seo-frontend/wix-seo-frontend.service.json
+++ b/wix-seo-frontend/wix-seo-frontend.service.json
@@ -294,8 +294,7 @@
         "extra":
           {  } },
       { "name": "addLinks",
-        "labels":
-          [ "new" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "links",
@@ -450,8 +449,7 @@
         "extra":
           {  } },
       { "name": "addMetaTags",
-        "labels":
-          [ "new" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "metaTags",

--- a/wix-seo-frontend/wix-seo-frontend.service.json
+++ b/wix-seo-frontend/wix-seo-frontend.service.json
@@ -40,7 +40,8 @@
                 " You should always invoke the `wixSeoFrontend.links` getter outside of the [`onReady()`]($w.html#onReady) event handler to",
                 " ensure receiving the proper response." ],
             "links":
-              [ "[setLinks( )](#setLinks)" ],
+              [ "[setLinks( )](#setLinks)",
+                "[addLinks( )](#addLinks)" ],
             "examples":
               [ { "title": "Get a page's link tags",
                   "body":
@@ -105,7 +106,8 @@
                 " You should always invoke the `wixSeoFrontend.metaTags` getter outside of the [`onReady()`]($w.html#onReady) event handler to",
                 " ensure receiving the proper response." ],
             "links":
-              [ "[setMetaTags( )](#setMetaTags)" ],
+              [ "[setMetaTags( )](#setMetaTags)",
+                "[addMetaTags( )](#addMetaTags)" ],
             "examples":
               [ { "title": "Get a page's meta tags",
                   "body":
@@ -257,7 +259,8 @@
                 ">",
                 "> * You cannot add a stylesheet link using the `setLinks` function." ],
             "links":
-              [ "[links](#links)" ],
+              [ "[links](#links)",
+                "[addLinks( )](#addLinks)" ],
             "examples":
               [ { "title": "Get a page's link tags",
                   "body":
@@ -282,6 +285,77 @@
                       "  } )",
                       "  .catch( () => {",
                       "    console.log(\"failed setting links\");",
+                      "  } );",
+                      "} );" ],
+                  "extra":
+                    {  } } ],
+            "extra":
+              {  } },
+        "extra":
+          {  } },
+      { "name": "addLinks",
+        "labels":
+          [ "new" ],
+        "nameParams": [],
+        "params":
+          [ { "name": "links",
+              "type":
+                { "name": "Array",
+                  "typeParams":
+                    [ "wix-seo-frontend.Link" ] },
+              "doc": "The links to add." } ],
+        "ret":
+          { "type":
+              { "name": "Promise",
+                "typeParams":
+                  [ "void" ] },
+            "doc": "Fulfilled - When the link tags are added." },
+        "locations":
+          [ { "lineno": 218,
+              "filename": "seo.js" } ],
+        "docs":
+          { "summary": "Adds SEO-related link tags to the page.",
+            "description":
+              [ "Use the `addLinks()` function to add SEO-related link tags without replacing",
+                " link tags previously set by the SEO API.",
+                "",
+                " The link tags you add provide additional SEO information about your page. For example,",
+                " you can add a link to the next or previous version of the current page.",
+                "",
+                " If an added link tag has the same `rel` as an existing link tag set by the SEO API,",
+                " the added link tag overwrites the existing one.",
+                "",
+                "> **Notes:**",
+                "> * You should always add the links inside the [`onReady()`]($w.html#onReady) event handler to ensure search engines can read it.",
+                ">",
+                "> * You cannot add a stylesheet link using the `addLinks` function." ],
+            "links":
+              [ "[links](#links)",
+                "[setLinks( )](#setLinks)" ],
+            "examples":
+              [ { "title": "Add a page's link tags",
+                  "body":
+                    [ "import wixSeoFrontend from 'wix-seo-frontend';",
+                      "",
+                      "// ...",
+                      "",
+                      "$w.onReady( () => {",
+                      "  wixSeoFrontend.addLinks(",
+                      "    [",
+                      "      {",
+                      "        \"rel\": \"next\",",
+                      "        \"href\": \"http://mysite.com/page/2\"",
+                      "      }, {",
+                      "        \"rel\": \"prev\",",
+                      "        \"href\": \"http://mysite.com/page/1\"",
+                      "      }",
+                      "    ]",
+                      "  )",
+                      "  .then( () => {",
+                      "    console.log(\"links added\");",
+                      "  } )",
+                      "  .catch( () => {",
+                      "    console.log(\"failed adding links\");",
                       "  } );",
                       "} );" ],
                   "extra":
@@ -341,7 +415,8 @@
                 ">",
                 "> * You should always set the `metaTags` inside the [`onReady()`]($w.html#onReady) event handler to ensure search engines can read it." ],
             "links":
-              [ "[metaTags](#metaTags)" ],
+              [ "[metaTags](#metaTags)",
+                "[addMetaTags( )](#addMetaTags)" ],
             "examples":
               [ { "title": "Set a page's meta tags",
                   "body":
@@ -366,6 +441,94 @@
                       "  } )",
                       "  .catch( () => {",
                       "    console.log(\"failed setting meta tags\");",
+                      "  } );",
+                      "} );" ],
+                  "extra":
+                    {  } } ],
+            "extra":
+              {  } },
+        "extra":
+          {  } },
+      { "name": "addMetaTags",
+        "labels":
+          [ "new" ],
+        "nameParams": [],
+        "params":
+          [ { "name": "metaTags",
+              "type":
+                { "name": "Array",
+                  "typeParams":
+                    [ "wix-seo-frontend.MetaTag" ] },
+              "doc": "The meta tags to add." } ],
+        "ret":
+          { "type":
+              { "name": "Promise",
+                "typeParams":
+                  [ "void" ] },
+            "doc": "Fulfilled - When the meta tags are added." },
+        "locations":
+          [ { "lineno": 166,
+              "filename": "seo.js" } ],
+        "docs":
+          { "summary": "Adds SEO-related meta tags to the page.",
+            "description":
+              [ "The `addMetaTags()` function creates SEO-related meta tags in the head of the page without replacing",
+                " meta tags previously set by the SEO API.",
+                "",
+                " The keys in the specified `metaTags` objects represent the keys in the tag, while the values in the",
+                " `metaTags` object represent the values in the tag.",
+                "",
+                " For example:",
+                "",
+                " ```javascript",
+                " {",
+                "   \"property\": \"og:image\",",
+                "   \"content\": \"https://.../Wix+logo.jpg\"",
+                " }",
+                " ```",
+                "",
+                "Produces:",
+                "",
+                " ```html",
+                " <meta property=\"og:image\" content=\"https://.../Wix+logo.jpg\"/>",
+                " ```",
+                "",
+                " When adding `og:image` meta tags, the `content` can be an external image URL",
+                " or a Media Manager image URL as described [here]($w.Image.html#src).",
+                "",
+                " If an added meta tag has the same `name` or `property` as an existing meta tag set by the SEO API,",
+                " the added meta tag overwrites the existing one.",
+                "> **Notes:**",
+                "> * Do not use `addMetaTags()` to create tags for the title. Use the [`setTitle()`](#setTitle) function instead.",
+                ">",
+                "> * You should always add the `metaTags` inside the [`onReady()`]($w.html#onReady) event handler to ensure search engines can read it." ],
+            "links":
+              [ "[metaTags](#metaTags)",
+                "[setMetaTags( )](#setMetaTags)" ],
+            "examples":
+              [ { "title": "Add a page's meta tags",
+                  "body":
+                    [ "import wixSeoFrontend from 'wix-seo-frontend';",
+                      "",
+                      "// ...",
+                      "",
+                      "$w.onReady( () => {",
+                      "  wixSeoFrontend.addMetaTags(",
+                      "    [",
+                      "      {",
+                      "        \"name\": \"description\",",
+                      "        \"content\": \"A page description added without replacing other SEO API meta tags\"",
+                      "      }, {",
+                      "        \"property\": \"og:title\",",
+                      "        \"content\": \"Updated Open Graph title\"",
+                      "      }",
+                      "    ]",
+                      "  )",
+                      "  .then( () => {",
+                      "    console.log(\"meta tags added\");",
+                      "  } )",
+                      "  .catch( () => {",
+                      "    console.log(\"failed adding meta tags\");",
                       "  } );",
                       "} );" ],
                   "extra":
@@ -504,7 +667,8 @@
           { "summary": "An object representing a link tag.",
             "links":
               [ "[links](#links)",
-                "[setLinks( )](#setLinks)" ],
+                "[setLinks( )](#setLinks)",
+                "[addLinks( )](#addLinks)" ],
             "examples":
               [ { "title": "Get a page's link tags",
                   "body":
@@ -577,7 +741,8 @@
           { "summary": "An object representing a meta tag.",
             "links":
               [ "[metaTags](#metaTags)",
-                "[setMetaTags( )](#setMetaTags)" ],
+                "[setMetaTags( )](#setMetaTags)",
+                "[addMetaTags( )](#addMetaTags)" ],
             "examples":
               [ { "title": "Get a page's meta tags",
                   "body":


### PR DESCRIPTION
Expose additive SEO frontend APIs in the source docs model so the auto flow can mirror them into sdk-manual-docs/manual-velo and publish them through @wix/site-seo.

Adds docs and examples for:
- wixSeoFrontend.addLinks
- wixSeoFrontend.addMetaTags

Jira: https://wix.atlassian.net/browse/WIXSEO-3896